### PR TITLE
Add `wordpress-plugin` type to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,6 @@
     "prefer-stable": true,
     "scripts": {
         "test": "wpcept run"
-    }
+    },
+    "type": "wordpress-plugin"
 }


### PR DESCRIPTION
Adding `wordpress-plugin` as type to composer makes the package compatible with [`composer-installers`](https://packagist.org/packages/composer/installers).
The `composer-installers` installer will place the plugin folder correctly into the site plugin folder, so WordPress can find and enable it as a plugin.